### PR TITLE
add an option to not build any packages that are not in the image 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,8 @@ rm -rf feeds
 rm -f .config
 git checkout .config
 if [ "Yes" = "$BUILD_BASE_ONLY" ]; then
-	sed 's/=m$/=n/' <.config >.baseonlyconfig
-	mv .config .origconfig; mv .baseonlyconfig .config;
+        sed 's/=m$/=n/' <.config >.baseonlyconfig
+        mv .config .origconfig; mv .baseonlyconfig .config;
 fi
 make oldconfig
 


### PR DESCRIPTION
replaces =m with =n in .config by setting BUILD_BASE_ONLY to "Yes"
reduces build time to ~ 1hr and reduces opportunities for problems
