### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Change the value of `MAKE_JOBS` to the number of your cores + 1. My pc has 4 cor
 
 ### Building the image only, skipping all optional packages
 
-Add `BUILD_BASE_ONLY=Yes` at the beggining of the command. Example: `BUILD_BASE_ONLY=Yes DL_FOLDER=~/DOWNLOAD ./build.sh`.
+Add `BUILD_BASE_ONLY=Yes` at the beginning of the command. Example: `BUILD_BASE_ONLY=Yes DL_FOLDER=~/DOWNLOAD ./build.sh`.
 
 
 ### Troubleshooting


### PR DESCRIPTION
@arduino, I've corrected a typographical error in the documentation of the [openwrt-yun](https://github.com/arduino/openwrt-yun) project. Specifically, I've changed beggining to beginning. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.